### PR TITLE
added possibility to obtain message prefix from parser

### DIFF
--- a/pkg/build/common/lib/abbozzaParser.cpp
+++ b/pkg/build/common/lib/abbozzaParser.cpp
@@ -85,7 +85,7 @@ void AbbozzaParser::setCommand(ManagedString line) {
     currentCommand = line;
     cmdId = "";
     cmd = "";
-    if ( currentCommand.charAt(0) == '_' ) {
+    if (indexOf(currentCommand,' ') >= 0) {
         cmdId = parse_word();
     }
     cmd = parse_word();
@@ -129,6 +129,10 @@ ManagedString AbbozzaParser::parse_string() {
     return result;
 }
 
+
+ManagedString AbbozzaParser::getCmdId() {
+    return cmdId;
+}
 
 ManagedString AbbozzaParser::getCmd() {
     return cmd;

--- a/pkg/build/common/lib/abbozzaParser.h
+++ b/pkg/build/common/lib/abbozzaParser.h
@@ -36,6 +36,7 @@ public:
     double parse_double();
     ManagedString parse_string();
     
+    ManagedString getCmdId();
     ManagedString getCmd();
     void execute();    
 


### PR DESCRIPTION
This patches the detection of a message prefix and adds an operation for obtaining the prefix of the last parsed message to the AbbozzaParser.